### PR TITLE
FIX Arbitrary Code Execution in jinjafx

### DIFF
--- a/jinjafx.py
+++ b/jinjafx.py
@@ -142,11 +142,11 @@ def main():
 
       return dst
 
-    yaml.add_constructor('!vault', yaml_vault_tag, yaml.FullLoader)
+    yaml.add_constructor('!vault', yaml_vault_tag, yaml.SafeLoader)
 
     if args.dt is not None:
       with open(args.dt.name) as f:
-        dt.update(yaml.load(f.read(), Loader=yaml.FullLoader)['dt'])
+        dt.update(yaml.load(f.read(), Loader=yaml.SafeLoader)['dt'])
         args.t = dt['template']
 
         if 'data' in dt:
@@ -155,7 +155,7 @@ def main():
         if 'vars' in dt:
           gyaml = decrypt_vault(dt['vars'])
           if gyaml:
-            gvars.update(yaml.load(gyaml, Loader=yaml.FullLoader))
+            gvars.update(yaml.load(gyaml, Loader=yaml.SafeLoader))
 
     if args.d is not None:
       with open(args.d.name) as f:
@@ -166,9 +166,9 @@ def main():
         with open(g.name) as f:
           gyaml = decrypt_vault(f.read())
           if args.m == True:
-            merge(gvars, yaml.load(gyaml, Loader=yaml.FullLoader))
+            merge(gvars, yaml.load(gyaml, Loader=yaml.SafeLoader))
           else:
-            gvars.update(yaml.load(gyaml, Loader=yaml.FullLoader))
+            gvars.update(yaml.load(gyaml, Loader=yaml.SafeLoader))
 
     if args.o is None:
       args.o = '_stdout_'


### PR DESCRIPTION
### 📊 Metadata *

JinjaFx is a Templating Tool that uses Jinja2 as the templating engine. It is written in Python and is extremely lightweight and hopefully simple - it doesn't require any Python modules that aren't in the base install, with the exception of jinja2 for obvious reasons, this pakacage is vulnerable for Arbitary Code execution

#### Bounty URL: 
https://www.huntr.dev/bounties/1-other-jinjafx
### ⚙️ Description *

Vulnerable to YAML deserialization attack caused by unsafe loading.

### 💻 Technical Description *

Fixed by avoiding unsafe loader (useing SafeLodaer instead of Fullloader)

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

![poc](https://user-images.githubusercontent.com/36979660/108682538-6dfd9e00-7516-11eb-821e-3474a04f4a87.png)



Execute the commands in another terminal:

xcalc will pop up.

### 🔥 Proof of Fix (PoF) *

![pof](https://user-images.githubusercontent.com/36979660/108682523-6938ea00-7516-11eb-9a67-ffea54151503.png)


### 👍 User Acceptance Testing (UAT)
After fix functionality is unaffected.

### 🔗 Relates to...
https://www.huntr.dev/bounties/1-other-jinjafx